### PR TITLE
ldb: add localization

### DIFF
--- a/ldb.lua
+++ b/ldb.lua
@@ -10,14 +10,6 @@ local click_actions = {
 	compressbags = core.CommandDecorator(core.Compress, 'bags'),
 	compressbank = core.CommandDecorator(core.Compress, 'bank'),
 }
-local name_map = {
-	sortbags = "Sort Bags",
-	sortbank = "Sort Bank",
-	stackbags = "Stack from bank to bags",
-	stackbank = "Stack from bags to bank",
-	compressbags = "Compress stacks in bags",
-	compressbank = "Compress stacks in bank",
-}
 local binding_order = {
 	'sortbags', 'sortbank', 'stackbags', 'stackbank', 'compressbags', 'compressbank',
 	--'BUTTON1', 'ALT-BUTTON1', 'CTRL-BUTTON1', 'ALT-CTRL-BUTTON1', 'SHIFT-BUTTON1',
@@ -41,10 +33,10 @@ local function build_current_keybind()
 end
 local function pretty_keybind(keybind)
 	-- Again, assumes left mouse button
-	return keybind and ((string.match(keybind, "ALT-") and "Alt-" or '') ..
-		(string.match(keybind, "CTRL-") and "Ctrl-" or '') ..
-		(string.match(keybind, "SHIFT-") and "Shift-" or '') ..
-		"Click") or 'None'
+	return keybind and ((string.match(keybind, "ALT-") and core.L["KEYBIND_PREFIX_ALT"] or '') ..
+		(string.match(keybind, "CTRL-") and core.L["KEYBIND_PREFIX_CTRL"] or '') ..
+		(string.match(keybind, "SHIFT-") and core.L["KEYBIND_PREFIX_SHIFT"] or '') ..
+		core.L["KEYBIND_CLICK"]) or core.L['KEYBIND_NONE']
 end
 
 local ldb = LibStub:GetLibrary("LibDataBroker-1.1")
@@ -59,7 +51,7 @@ dataobject.OnClick = function(frame, button)
 		return InterfaceOptionsFrame_OpenToCategory(LibStub("AceConfigDialog-3.0").BlizOptions.BankStack.BankStack.frame)
 	end
 	if #(core.moves) > 0 then
-		return core.StopStacking("BankStack: Aborted.")
+		return core.StopStacking(core.L['CHAT_MSG_ABORTED'])
 	end
 	--Build the keybind that triggered this.  There might be a better way to do this.
 	local keybind = build_current_keybind()
@@ -71,9 +63,9 @@ end
 dataobject.OnTooltipShow = function(tooltip)
 	tooltip:AddLine("BankStack")
 	for _, action in ipairs(binding_order) do
-		tooltip:AddDoubleLine(pretty_keybind(get_binding_for_action(action)), name_map[action], 0, 1, 0, 1, 1, 1)
+		tooltip:AddDoubleLine(pretty_keybind(get_binding_for_action(action)), core.L['ACTION_' .. action:upper()], 0, 1, 0, 1, 1, 1)
 	end
-	tooltip:AddDoubleLine("Click while stacking", "Abort", 1, 0, 0, 1, 0, 0)
+	tooltip:AddDoubleLine(core.L['KEYBIND_CLICK_WHILE_STACKING'], core.L['ACTION_ABORT'], 1, 0, 0, 1, 0, 0)
 end
 
 local db
@@ -91,8 +83,8 @@ function module:OnInitialize()
 		core.options.plugins.ldb = {
 			minimap = {
 				type = "toggle",
-				name = "Show minimap icon",
-				desc = "Toggle showing or hiding the minimap icon.",
+				name = core.L['OPTIONS_SHOW_MINIMAP_ICON'],
+				desc = core.L['OPTIONS_SHOW_MINIMAP_ICON_DESCRIPTION'],
 				get = function() return not db.profile.minimap.hide end,
 				set = function(info, v)
 					local hide = not v
@@ -112,7 +104,7 @@ function module:OnInitialize()
 end
 
 core.RegisterCallback("LDB", "Doing_Moves", function(callback, num_moves)
-	dataobject.text = num_moves .. " moves to go"
+	dataobject.text = core.L['CHAT_MSG_TO_MOVE_NOPREFIX'].format(num_moves)
 end)
 
 core.RegisterCallback("LDB", "Stacking_Stopped", function(callback, message)

--- a/local.enUS.lua
+++ b/local.enUS.lua
@@ -36,3 +36,25 @@ L['BINDING_HEADER_BANKSTACK_HEAD'] = "BankStack"
 L['BINDING_NAME_BANKSTACK'] = "Stack to bank"
 L['BINDING_NAME_COMPRESS'] = "Compress bags"
 L['BINDING_NAME_BAGSORT'] = "Sorts bags"
+
+-- ldb:
+L['ACTION_ABORT'] = "Abort"
+L['ACTION_COMPRESSBAGS'] = "Compress stacks in bags"
+L['ACTION_COMPRESSBANK'] = "Compress stacks in bank"
+L['ACTION_SORTBAGS'] = "Sort Bags"
+L['ACTION_SORTBANK'] = "Sort Bank"
+L['ACTION_STACKBAGS'] = "Stack from bank to bags"
+L['ACTION_STACKBANK'] = "Stack from bags to bank"
+
+L['KEYBIND_CLICK'] = "Click"
+L['KEYBIND_CLICK_WHILE_STACKING'] = "Click while stacking"
+L['KEYBIND_NONE'] = "None"
+L['KEYBIND_PREFIX_ALT'] = "Alt-"
+L['KEYBIND_PREFIX_CTRL'] = "Ctrl-"
+L['KEYBIND_PREFIX_SHIFT'] = "Shift-"
+
+L['CHAT_MSG_ABORTED'] = "BankStack: Aborted."
+L['CHAT_MSG_TO_MOVE_NOPREFIX'] = "%d moves to make."
+
+L['OPTIONS_SHOW_MINIMAP_ICON'] = "Show minimap icon"
+L['OPTIONS_SHOW_MINIMAP_ICON_DESCRIPTION'] = "Toggle showing or hiding the minimap icon."


### PR DESCRIPTION
![image](https://github.com/kemayo/wow-bankstack/assets/2866005/2a7f04ed-5313-4421-9f8d-eb089efdc427)

## deDE

```
L['ACTION_ABORT'] = "Abbrechen"
L['ACTION_COMPRESSBAGS'] = "Stapel in Taschen komprimieren"
L['ACTION_COMPRESSBANK'] = "Stapel in Bank komprimieren"
L['ACTION_SORTBAGS'] = "Taschen sortieren"
L['ACTION_SORTBANK'] = "Bank sortieren"
L['ACTION_STACKBAGS'] = "Von Bank zu Taschen stapeln"
L['ACTION_STACKBANK'] = "Von Taschen zu Bank stapeln"

L['KEYBIND_CLICK'] = "Klick"
L['KEYBIND_CLICK_WHILE_STACKING'] = "Während dem Sortieren klicken"
L['KEYBIND_NONE'] = "Unzugewiesen"
L['KEYBIND_PREFIX_ALT'] = "Alt-"
L['KEYBIND_PREFIX_CTRL'] = "Strg-"
L['KEYBIND_PREFIX_SHIFT'] = "Shift-"

L['CHAT_MSG_ABORTED'] = "BankStack: Abgebrochen."
L['CHAT_MSG_TO_MOVE_NOPREFIX'] = "%d Bewegungen zu machen"

L['OPTIONS_SHOW_MINIMAP_ICON'] = "Zeige Minimap-Icon"
L['OPTIONS_SHOW_MINIMAP_ICON_DESCRIPTION'] = "Schalte Sichtbarkeit des Minimap-Icons um."
```