### PR TITLE
Fix bank tab sorting

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -525,6 +525,9 @@ function core.CanItemGoInBag(bag, slot, target_bag)
 	end
 	if core.has_new_bank and BTSI and is_bank_bag(target_bag) then
 		if core.db.ignore_blizzard and BTSI then
+			if is_bank_bag(bag) then
+				return BTSI:IsItemSuitableForTab(item, target_bag)
+			end
 			return BTSI:IsItemLocationSuitableForTab(core.bag_itemlocation[bagslot], target_bag)
 		end
 		-- This is filtering out the actually-impossible, not just preference-based:

--- a/sort.lua
+++ b/sort.lua
@@ -9,6 +9,79 @@ local moves = core.moves
 
 local bagcache = {}
 local bag_groups = {}
+
+local function item_fits_bag(bag, slot, target_bag)
+	return core.CanItemGoInBag(bag, slot, target_bag)
+end
+
+local function item_fits_own_bag(bag, slot)
+	return item_fits_bag(bag, slot, bag)
+end
+
+local function move_into_group(source_bags, target_bags, only_misplaced)
+	local before = #moves
+	local function can_move(itemid, bag, slot)
+		if only_misplaced and item_fits_own_bag(bag, slot) then
+			return false
+		end
+		return item_fits_bag(bag, slot, target_bags[1])
+	end
+
+	core.Stack(source_bags, target_bags, can_move)
+	core.Fill(source_bags, target_bags, core.db.reverse, can_move)
+
+	return #moves > before
+end
+
+local function swap_into_group(source_bags, target_bags, only_misplaced)
+	for _, source_bag, source_slot in core.IterateBags(source_bags, true, "withdraw") do
+		local source = encode_bagslot(source_bag, source_slot)
+		if not core.IsIgnored(source_bag, source_slot) and core.bag_ids[source] then
+			if (not only_misplaced or not item_fits_own_bag(source_bag, source_slot)) and item_fits_bag(source_bag, source_slot, target_bags[1]) then
+				for _, target_bag, target_slot in core.IterateBags(target_bags, false, "deposit") do
+					local target = encode_bagslot(target_bag, target_slot)
+					if
+						source ~= target
+						and not core.IsIgnored(target_bag, target_slot)
+						and core.bag_ids[target]
+						and not item_fits_own_bag(target_bag, target_slot)
+						and item_fits_bag(target_bag, target_slot, source_bag)
+					then
+						core.AddMove(source, target)
+						return true
+					end
+				end
+			end
+		end
+	end
+
+	return false
+end
+
+local function route_items_between_groups()
+	local changed = true
+	local passes = 0
+
+	while changed and passes < 20 do
+		changed = false
+		passes = passes + 1
+
+		for source_type, source_bags in pairs(bagcache) do
+			local only_misplaced = source_type ~= 'Normal'
+			for target_type, target_bags in pairs(bagcache) do
+				if source_type ~= target_type then
+					if move_into_group(source_bags, target_bags, only_misplaced) then
+						changed = true
+					end
+					if swap_into_group(source_bags, target_bags, only_misplaced) then
+						changed = true
+					end
+				end
+			end
+		end
+	end
+end
+
 function core.SortBags(...)
 	local start = 1
 	local sorter
@@ -26,6 +99,9 @@ function core.SortBags(...)
 			table.insert(bagcache[bagtype], bag)
 			Debug(" went with", bag, bagtype)
 		end
+
+		route_items_between_groups()
+
 		for bagtype, sorted_bags in pairs(bagcache) do
 			if bagtype ~= 'Normal' then
 				Debug("Moving to normal from", bagtype)


### PR DESCRIPTION
Fixes bank sorting when bank tab restrictions are involved - it was only partially implemented.
                                                                                                       
Right now BankStack can recognize that restricted tabs are different, but it still struggles when items need to move from one restricted tab to another. That shows up most clearly with expansion-based tabs, where sorting can leave items in the wrong place even though the addon knows the tabs are  not the same.                                                                                        
                                                                                                       
Changes:
- when checking whether an item can go into a bank tab, it handles items that are already in another  bank tab more directly                                                                             
- before the normal per-group sorting step, it does an extra routing pass so items can move or swap between restricted tab groups instead of getting stuck in the wrong bucket

In game, this fixed the remaining issue after updating the library (see PR on lib-banktabsuitableitems which is required to be updated first for this PR to work).  The lib update should be harmless and backwards compat. but adds some new methods this PR on BankStack is using, that exposes more data needed for sorting properly.
